### PR TITLE
Add config options for USB device to specify custom VID & PID

### DIFF
--- a/esphome/components/usb_device/__init__.py
+++ b/esphome/components/usb_device/__init__.py
@@ -79,10 +79,8 @@ async def to_code(config):
         cg.add_define("USE_PRODUCT_ID")
         cg.add(var.set_product_id(config[CONF_PRODUCT_ID]))
     if CONF_MANUFACTURER_NAME in config:
-        cg.add_define("USE_MANUFACTURER_NAME")
         cg.add(var.set_manufacturer_name(config[CONF_MANUFACTURER_NAME]))
     if CONF_PRODUCT_NAME in config:
-        cg.add_define("USE_PRODUCT_NAME")
         cg.add(var.set_product_name(config[CONF_PRODUCT_NAME]))
 
     await cg.register_component(var, config)

--- a/esphome/components/usb_device/__init__.py
+++ b/esphome/components/usb_device/__init__.py
@@ -17,6 +17,8 @@ CODEOWNERS = ["@tomaszduda23"]
 CONF_USB_DEVICE_ID = "usb_device_id"
 CONF_VENDOR_ID = "vendor_id"
 CONF_PRODUCT_ID = "product_id"
+CONF_MANUFACTURER_NAME = "manufacturer_name"
+CONF_PRODUCT_NAME = "product_name"
 
 
 def _validate_variant(value):
@@ -37,6 +39,8 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(UsbDevice),
             cv.Optional(CONF_VENDOR_ID): cv.hex_uint16_t,
             cv.Optional(CONF_PRODUCT_ID): cv.hex_uint16_t,
+            cv.Optional(CONF_MANUFACTURER_NAME): cv.string,
+            cv.Optional(CONF_PRODUCT_NAME): cv.string,
         }
     ).extend(cv.polling_component_schema("10s")),
     cv.only_with_arduino,
@@ -74,6 +78,12 @@ async def to_code(config):
     if CONF_PRODUCT_ID in config:
         cg.add_define("USE_PRODUCT_ID")
         cg.add(var.set_product_id(config[CONF_PRODUCT_ID]))
+    if CONF_MANUFACTURER_NAME in config:
+        cg.add_define("USE_MANUFACTURER_NAME")
+        cg.add(var.set_manufacturer_name(config[CONF_MANUFACTURER_NAME]))
+    if CONF_PRODUCT_NAME in config:
+        cg.add_define("USE_PRODUCT_NAME")
+        cg.add(var.set_product_name(config[CONF_PRODUCT_NAME]))
 
     await cg.register_component(var, config)
     cg.add_library("adafruit/Adafruit TinyUSB Library", "2.2.4", None)

--- a/esphome/components/usb_device/__init__.py
+++ b/esphome/components/usb_device/__init__.py
@@ -15,6 +15,8 @@ from esphome.components.hid import CONF_HID
 
 CODEOWNERS = ["@tomaszduda23"]
 CONF_USB_DEVICE_ID = "usb_device_id"
+CONF_VENDOR_ID = "vendor_id"
+CONF_PRODUCT_ID = "product_id"
 
 
 def _validate_variant(value):
@@ -33,6 +35,8 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(UsbDevice),
+            cv.Optional(CONF_VENDOR_ID): cv.hex_uint16_t,
+            cv.Optional(CONF_PRODUCT_ID): cv.hex_uint16_t,
         }
     ).extend(cv.polling_component_schema("10s")),
     cv.only_with_arduino,
@@ -64,6 +68,13 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    if CONF_VENDOR_ID in config:
+        cg.add_define("USE_VENDOR_ID")
+        cg.add(var.set_vendor_id(config[CONF_VENDOR_ID]))
+    if CONF_PRODUCT_ID in config:
+        cg.add_define("USE_PRODUCT_ID")
+        cg.add(var.set_product_id(config[CONF_PRODUCT_ID]))
+
     await cg.register_component(var, config)
     cg.add_library("adafruit/Adafruit TinyUSB Library", "2.2.4", None)
     cg.add_build_flag("-DCFG_TUSB_MCU=OPT_MCU_ESP32S2")

--- a/esphome/components/usb_device/usb_device.cpp
+++ b/esphome/components/usb_device/usb_device.cpp
@@ -9,7 +9,15 @@ namespace usb_device {
 
 static const char *const TAG = "usb_device";
 
-void UsbDevice::setup() { USB.begin(); }
+void UsbDevice::setup() {
+#ifdef USE_VENDOR_ID
+  USB.VID(this->vendor_id_);
+#endif
+#ifdef USE_PRODUCT_ID
+  USB.PID(this->product_id_);
+#endif
+  USB.begin();
+}
 
 void UsbDevice::update() {
 #ifdef USE_BINARY_SENSOR
@@ -34,6 +42,13 @@ void UsbDevice::dump_config() {
   ESP_LOGCONFIG(TAG, "USB device - mounted: %s, suspended: %s, ready: %s", YESNO(TinyUSBDevice.mounted()),
                 YESNO(TinyUSBDevice.suspended()), YESNO(TinyUSBDevice.ready()));
 }
+
+#ifdef USE_VENDOR_ID
+void UsbDevice::set_vendor_id(const uint16_t vid) { this->vendor_id_ = vid; }
+#endif
+#ifdef USE_PRODUCT_ID
+void UsbDevice::set_product_id(const uint16_t pid) { this->product_id_ = pid; }
+#endif
 
 #ifdef USE_BINARY_SENSOR
 void UsbDevice::set_mounted_binary_sensor(binary_sensor::BinarySensor *sensor) { mounted_ = sensor; };

--- a/esphome/components/usb_device/usb_device.cpp
+++ b/esphome/components/usb_device/usb_device.cpp
@@ -16,6 +16,12 @@ void UsbDevice::setup() {
 #ifdef USE_PRODUCT_ID
   USB.PID(this->product_id_);
 #endif
+#ifdef USE_MANUFACTURER_NAME
+  USB.manufacturerName(this->manufacturer_name_.c_str());
+#endif
+#ifdef USE_PRODUCT_NAME
+  USB.productName(this->product_name_.c_str());
+#endif
   USB.begin();
 }
 
@@ -48,6 +54,12 @@ void UsbDevice::set_vendor_id(const uint16_t vid) { this->vendor_id_ = vid; }
 #endif
 #ifdef USE_PRODUCT_ID
 void UsbDevice::set_product_id(const uint16_t pid) { this->product_id_ = pid; }
+#endif
+#ifdef USE_MANUFACTURER_NAME
+void UsbDevice::set_manufacturer_name(const std::string &manufacturer_name) { this->manufacturer_name_ = manufacturer_name; }
+#endif
+#ifdef USE_PRODUCT_NAME
+void UsbDevice::set_product_name(const std::string &product_name) { this->product_name_ = product_name; }
 #endif
 
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/usb_device/usb_device.cpp
+++ b/esphome/components/usb_device/usb_device.cpp
@@ -16,12 +16,12 @@ void UsbDevice::setup() {
 #ifdef USE_PRODUCT_ID
   USB.PID(this->product_id_);
 #endif
-#ifdef USE_MANUFACTURER_NAME
-  USB.manufacturerName(this->manufacturer_name_.c_str());
-#endif
-#ifdef USE_PRODUCT_NAME
-  USB.productName(this->product_name_.c_str());
-#endif
+  if (!this->manufacturer_name_.empty()) {
+    USB.manufacturerName(this->manufacturer_name_.c_str());
+  }
+  if (!this->product_name_.empty()) {
+    USB.productName(this->product_name_.c_str());
+  }
   USB.begin();
 }
 
@@ -49,18 +49,10 @@ void UsbDevice::dump_config() {
                 YESNO(TinyUSBDevice.suspended()), YESNO(TinyUSBDevice.ready()));
 }
 
-#ifdef USE_VENDOR_ID
 void UsbDevice::set_vendor_id(const uint16_t vid) { this->vendor_id_ = vid; }
-#endif
-#ifdef USE_PRODUCT_ID
 void UsbDevice::set_product_id(const uint16_t pid) { this->product_id_ = pid; }
-#endif
-#ifdef USE_MANUFACTURER_NAME
 void UsbDevice::set_manufacturer_name(const std::string &manufacturer_name) { this->manufacturer_name_ = manufacturer_name; }
-#endif
-#ifdef USE_PRODUCT_NAME
 void UsbDevice::set_product_name(const std::string &product_name) { this->product_name_ = product_name; }
-#endif
 
 #ifdef USE_BINARY_SENSOR
 void UsbDevice::set_mounted_binary_sensor(binary_sensor::BinarySensor *sensor) { mounted_ = sensor; };

--- a/esphome/components/usb_device/usb_device.h
+++ b/esphome/components/usb_device/usb_device.h
@@ -14,12 +14,24 @@ class UsbDevice : public PollingComponent {
   void update() override;
   float get_setup_priority() const override;
   void dump_config() override;
+#ifdef USE_VENDOR_ID
+  void set_vendor_id(uint16_t vendor_id);
+#endif
+#ifdef USE_PRODUCT_ID
+  void set_product_id(uint16_t product_id);
+#endif
 #ifdef USE_BINARY_SENSOR
   void set_mounted_binary_sensor(binary_sensor::BinarySensor *sensor);
   void set_ready_binary_sensor(binary_sensor::BinarySensor *sensor);
   void set_suspended_binary_sensor(binary_sensor::BinarySensor *sensor);
 #endif
  protected:
+#ifdef USE_VENDOR_ID
+  uint16_t vendor_id_;
+#endif
+#ifdef USE_PRODUCT_ID
+  uint16_t product_id_;
+#endif
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *mounted_;
   binary_sensor::BinarySensor *ready_;

--- a/esphome/components/usb_device/usb_device.h
+++ b/esphome/components/usb_device/usb_device.h
@@ -20,6 +20,12 @@ class UsbDevice : public PollingComponent {
 #ifdef USE_PRODUCT_ID
   void set_product_id(uint16_t product_id);
 #endif
+#ifdef USE_MANUFACTURER_NAME
+  void set_manufacturer_name(const std::string &manufacturer_name);
+#endif
+#ifdef USE_PRODUCT_NAME
+  void set_product_name(const std::string &product_name);
+#endif
 #ifdef USE_BINARY_SENSOR
   void set_mounted_binary_sensor(binary_sensor::BinarySensor *sensor);
   void set_ready_binary_sensor(binary_sensor::BinarySensor *sensor);
@@ -31,6 +37,12 @@ class UsbDevice : public PollingComponent {
 #endif
 #ifdef USE_PRODUCT_ID
   uint16_t product_id_;
+#endif
+#ifdef USE_MANUFACTURER_NAME
+  std::string manufacturer_name_;
+#endif
+#ifdef USE_PRODUCT_NAME
+  std::string product_name_;
 #endif
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *mounted_;

--- a/esphome/components/usb_device/usb_device.h
+++ b/esphome/components/usb_device/usb_device.h
@@ -14,36 +14,20 @@ class UsbDevice : public PollingComponent {
   void update() override;
   float get_setup_priority() const override;
   void dump_config() override;
-#ifdef USE_VENDOR_ID
   void set_vendor_id(uint16_t vendor_id);
-#endif
-#ifdef USE_PRODUCT_ID
   void set_product_id(uint16_t product_id);
-#endif
-#ifdef USE_MANUFACTURER_NAME
   void set_manufacturer_name(const std::string &manufacturer_name);
-#endif
-#ifdef USE_PRODUCT_NAME
   void set_product_name(const std::string &product_name);
-#endif
 #ifdef USE_BINARY_SENSOR
   void set_mounted_binary_sensor(binary_sensor::BinarySensor *sensor);
   void set_ready_binary_sensor(binary_sensor::BinarySensor *sensor);
   void set_suspended_binary_sensor(binary_sensor::BinarySensor *sensor);
 #endif
  protected:
-#ifdef USE_VENDOR_ID
   uint16_t vendor_id_;
-#endif
-#ifdef USE_PRODUCT_ID
   uint16_t product_id_;
-#endif
-#ifdef USE_MANUFACTURER_NAME
   std::string manufacturer_name_;
-#endif
-#ifdef USE_PRODUCT_NAME
   std::string product_name_;
-#endif
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *mounted_;
   binary_sensor::BinarySensor *ready_;


### PR DESCRIPTION
# What does this implement/fix?

Since my target PC didn't accept an HID keyboard with the Lolin S2 USB IDs, I had to extend this to be able to configure custom vendor & product IDs for the usb_device.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
usb_device:
  vendor_id: 0x413c
  product_id: 0x2113
  manufacturer_name: "Dell"
  product_name: "Dell KB216 Wired Keyboard"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
